### PR TITLE
add request object in filters

### DIFF
--- a/djadmin2/filters.py
+++ b/djadmin2/filters.py
@@ -69,6 +69,7 @@ def build_list_filter(request, model_admin, queryset):
     if not isinstance(model_admin.list_filter, collections.Iterable):
         return model_admin.list_filter(
             request.GET,
+            request=request,
             queryset=queryset,
         )
     # otherwise build :mod:`django_filters.FilterSet`


### PR DESCRIPTION
A really basic change, but pretty helpful. Allows for filtering your filters (hah) for the correct context. In this instance I wanted to only show filters that were specific to the request.user and the request.site.