### PR TITLE
Fix: "there are no" instead "there isn't" on the empty form message.

### DIFF
--- a/djadmin2/themes/djadmin2theme_default/templates/djadmin2theme_default/edit_inlines/stacked.html
+++ b/djadmin2/themes/djadmin2theme_default/templates/djadmin2theme_default/edit_inlines/stacked.html
@@ -5,7 +5,7 @@
   {{ inline_form|crispy }}
   {% if not inline_form.visible_fields %}
     <p class="alert alert-warning empty-form">
-      {% trans "This form doesn't have visible fields. This doesn't mean there isn't hidden fields." %}
+      {% trans "This form doesn't have visible fields. This doesn't mean there are no hidden fields." %}
     </p>
   {% endif %}
   </div>

--- a/djadmin2/themes/djadmin2theme_default/templates/djadmin2theme_default/edit_inlines/tabular.html
+++ b/djadmin2/themes/djadmin2theme_default/templates/djadmin2theme_default/edit_inlines/tabular.html
@@ -24,7 +24,7 @@
       {% if not inline_form.visible_fields %}
       <td>
         <p class="alert alert-warning empty-form">
-          {% trans "This form doesn't have visible fields. This doesn't mean there isn't hidden fields." %}
+          {% trans "This form doesn't have visible fields. This doesn't mean there are no hidden fields." %}
         </p>
       </td>
       {% endif %}

--- a/djadmin2/themes/djadmin2theme_default/templates/djadmin2theme_default/model_update_form.html
+++ b/djadmin2/themes/djadmin2theme_default/templates/djadmin2theme_default/model_update_form.html
@@ -56,7 +56,7 @@
         {{ form|crispy }}
         {% if not form.visible_fields %}
           <p class="alert alert-warning empty-form">
-            {% trans "This form doesn't have visible fields. This doesn't mean there isn't hidden fields." %}
+            {% trans "This form doesn't have visible fields. This doesn't mean there are no hidden fields." %}
           </p>
         {% endif %}
       {% for formset in inlines %}


### PR DESCRIPTION
Reported here: https://github.com/pydanny/django-admin2/commit/b169d28653f747d662baae86453970acc82bd3c3#commitcomment-4888932
( need to practice my english =/ )